### PR TITLE
Roll back to GNOME 43

### DIFF
--- a/io.bassi.Amberol.json
+++ b/io.bassi.Amberol.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.bassi.Amberol",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "44",
+    "runtime-version" : "43",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
The Rust bindings for GTK have broken backward compatibility between GNOME 43 and GNOME 44. The changes have been fixed in the main development branch, but I need to release a new version of Amberol if I want to bump the run time.